### PR TITLE
Add missing click dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "importlib-resources",
   "ros_introspect",
   "PyYAML",
+  "click"
 ]
 
 requires-python = ">=3.8"


### PR DESCRIPTION
Without it:

```
> glint_ros
Traceback (most recent call last):
  File "/usr/local/bin/glint_ros", line 5, in <module>
    from ros_glint.main import main
  File "/usr/local/lib/python3.8/dist-packages/ros_glint/main.py", line 2, in <module>
    import click
ModuleNotFoundError: No module named 'click'
```